### PR TITLE
Making latexmkrc compatible with older versions

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,28 +1,27 @@
 # build pdfs
-push @extra_pdflatex_options, '-synctex=1' ;
 $pdf_mode = 1;
 $interaction = "nonstopmode";
+push @extra_pdflatex_options, '-synctex=1';
 
 # Ignore any locally installed files to make builds reproducible
-#
+
 # (? is a deliberately chosen, invalid path. Unsetting the environment
 # variable or setting it to the empty string would have LaTeX search the
 # default texmf directory location, which we can only avoid by using an
 # invalid path)
+$ENV{'TEXMFHOME'} = '?';
 
 # Reset all search paths
-if ( defined( &ensure_path ) ){
-    delete $ENV{'TEXMFHOME'};
-    delete $ENV{'BIBINPUTS'};
-    delete $ENV{'BSTINPUTS'};
-    delete $ENV{'TEXINPUTS'};
-    ensure_path('BIBINPUTS', '?' );
-    ensure_path('BIBINPUTS', './include//' );
-    ensure_path('BSTINPUTS', './include//' );
-    ensure_path('TEXINPUTS', './include//' );
+delete $ENV{'BIBINPUTS'};
+delete $ENV{'BSTINPUTS'};
+delete $ENV{'TEXINPUTS'};
+
+if ( defined &ensure_path ) {
+    ensure_path('BIBINPUTS', './include//');
+    ensure_path('BSTINPUTS', './include//');
+    ensure_path('TEXINPUTS', './include//');
 }
-else{
-    $ENV{'TEXMFHOME'} = '?';
+else {
     $ENV{'BIBINPUTS'} = './include//:';
     $ENV{'BSTINPUTS'} = './include//:';
     $ENV{'TEXINPUTS'} = './include//:';

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,4 +1,5 @@
 # build pdfs
+push @extra_pdflatex_options, '-synctex=1' ;
 $pdf_mode = 1;
 $interaction = "nonstopmode";
 
@@ -8,9 +9,21 @@ $interaction = "nonstopmode";
 # variable or setting it to the empty string would have LaTeX search the
 # default texmf directory location, which we can only avoid by using an
 # invalid path)
-$ENV{"TEXMFHOME"} = "?";
 
 # Reset all search paths
-ensure_path( 'BIBINPUTS', './include//' );
-ensure_path( 'BSTINPUTS', './include//' );
-ensure_path( 'TEXINPUTS', './include//' );
+if ( defined( &ensure_path ) ){
+    delete $ENV{'TEXMFHOME'};
+    delete $ENV{'BIBINPUTS'};
+    delete $ENV{'BSTINPUTS'};
+    delete $ENV{'TEXINPUTS'};
+    ensure_path('BIBINPUTS', '?' );
+    ensure_path('BIBINPUTS', './include//' );
+    ensure_path('BSTINPUTS', './include//' );
+    ensure_path('TEXINPUTS', './include//' );
+}
+else{
+    $ENV{'TEXMFHOME'} = '?';
+    $ENV{'BIBINPUTS'} = './include//:';
+    $ENV{'BSTINPUTS'} = './include//:';
+    $ENV{'TEXINPUTS'} = './include//:';
+}

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -11,9 +11,6 @@ $interaction = "nonstopmode";
 $ENV{"TEXMFHOME"} = "?";
 
 # Reset all search paths
-delete $ENV{'BIBINPUTS'};
-delete $ENV{'BSTINPUTS'};
-delete $ENV{'TEXINPUTS'};
-ensure_path('BIBINPUTS', './include//');
-ensure_path('BSTINPUTS', './include//');
-ensure_path('TEXINPUTS', './include//');
+ensure_path( 'BIBINPUTS', './include//' );
+ensure_path( 'BSTINPUTS', './include//' );
+ensure_path( 'TEXINPUTS', './include//' );


### PR DESCRIPTION
It seems that old versions of latexmk do not have the function "ensure_path()'.
In that case, this patch resorts to set the variable directly.
In particular, this problem affects Pedro.
Probably the current patch will not work on old versions of latexmk running on Windows, but it seems to work on old versions on latexmk on Linux and MacOs and it should work on all new version of latexmk independently of the platform.